### PR TITLE
Fix for "navigator is not defined" when running in non-browser(nodejs…

### DIFF
--- a/jsbn.js
+++ b/jsbn.js
@@ -97,11 +97,11 @@ function am3(i,x,w,j,c,n) {
   }
   return c;
 }
-if(j_lm && (navigator.appName == "Microsoft Internet Explorer")) {
+if(j_lm && typeof navigator !== 'undefined' && (navigator.appName == "Microsoft Internet Explorer")) {
   BigInteger.prototype.am = am2;
   dbits = 30;
 }
-else if(j_lm && (navigator.appName != "Netscape")) {
+else if(j_lm && typeof navigator !== 'undefined' && (navigator.appName != "Netscape")) {
   BigInteger.prototype.am = am1;
   dbits = 26;
 }


### PR DESCRIPTION
…) mode

Fix for "navigator is not defined" when running in non-browser(nodejs) mode